### PR TITLE
Suggesting update to CIEL URL

### DIFF
--- a/fsh/who-cr-Common.fsh
+++ b/fsh/who-cr-Common.fsh
@@ -1,5 +1,5 @@
 Alias: $LNC = http://loinc.org
-Alias: $CIEL = https://www.openconceptlab.org/orgs/CIEL/sources/CIEL/concepts
+Alias: $CIEL = https://openconceptlab.org/orgs/CIEL/sources/CIEL
 Alias: $ICD10 = https://icd.who.int/browse10
 Alias: $ICD11 = https://icd.who.int/browse11
 Alias: $RXNORM = http://www.nlm.nih.gov/research/umls/rxnorm


### PR DESCRIPTION
Rationale: This is what we are using internally in the OpenMRS FHIR module (we're the primary consumers of the CIEL concept set).